### PR TITLE
Add goreleaser and version support

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,31 @@
+builds:
+- env:
+  - CGO_ENABLED=0
+  goos:
+    - darwin
+    - linux
+    - windows
+  goarch:
+    - amd64
+  ldflags:
+    - "-w -s -X github.com/chanzuckerberg/czecs/version.GitSha={{.Commit}} -X github.com/chanzuckerberg/czecs/version.Version={{.Version}} -X github.com/chanzuckerberg/czecs/version.Dirty=false -X github.com/chanzuckerberg/czecs/version.Release=true"
+
+archive:
+  format_overrides:
+  - goos: windows
+    format: zip
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+    - '^docs:'
+    - '^test:'
+
+brew:
+  description: "ECS release management tool."
+  github:
+    owner: chanzuckerberg
+    name: homebrew-czecs
+  homepage: "https://github.com/chanzuckerberg/czecs"
+  test: system "#{bin}/czecs version"

--- a/README.md
+++ b/README.md
@@ -1,2 +1,17 @@
 # czecs
 CLI deployment tool for AWS Elastic Container Service
+
+## Install
+
+## Mac
+
+You can use homebrew to install czecs –
+
+```
+brew tap chanzuckerberg/homebrew-czecs
+brew install czecs
+```
+
+## Linux, Windows, etc.
+
+Binaries are available on the [Releases](https://github.com/chanzuckerberg/czecs/releases) page. Download one for your architecture, put it in your path and make it executable.

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,0 +1,37 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/chanzuckerberg/czecs/version"
+	"github.com/spf13/cobra"
+)
+
+type versionCmd struct{}
+
+func init() {
+	rootCmd.AddCommand(newVersionCmd())
+}
+
+func newVersionCmd() *cobra.Command {
+	version := &versionCmd{}
+	cmd := &cobra.Command{
+		Use:          "version",
+		Short:        "Print the version number of czecs",
+		SilenceUsage: true,
+		Args:         cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return version.run()
+		},
+	}
+	return cmd
+}
+
+func (v *versionCmd) run() error {
+	ver, err := version.VersionString()
+	if err != nil {
+		return err
+	}
+	fmt.Println(ver)
+	return nil
+}

--- a/version/version.go
+++ b/version/version.go
@@ -1,0 +1,37 @@
+package version
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/pkg/errors"
+)
+
+var (
+	Version = "undefined"
+	GitSha  = "undefined"
+	Release = "false"
+	Dirty   = "true"
+)
+
+func VersionString() (string, error) {
+	release, e := strconv.ParseBool(Release)
+	if e != nil {
+		return "", errors.Wrapf(e, "unable to parse version release field %s", Release)
+	}
+	dirty, e := strconv.ParseBool(Dirty)
+	if e != nil {
+		return "", errors.Wrapf(e, "unable to parse version dirty field %s", Dirty)
+	}
+	return versionString(Version, GitSha, release, dirty), nil
+}
+
+func versionString(version, sha string, release, dirty bool) string {
+	if release {
+		return version
+	}
+	if !dirty {
+		return fmt.Sprintf("%s-%s", version, sha)
+	}
+	return fmt.Sprintf("%s-%s-dirty", version, sha)
+}


### PR DESCRIPTION
This PR adds support for goreleaser to Czecs to create standalone binaries. I intend to tag and release v0.1.0 after this is committed. I have already created the corresponding Homebrew repo at chanzuckerberg/homebrew-czecs